### PR TITLE
Update .gitignore for Coq master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
-*.v.d
+*.d
 *.vo
 *.glob
 *.aux
 /Makefile.conf
+/Makefile.coq.conf
 *~
-.coqdeps.d
-


### PR DESCRIPTION
After https://github.com/coq/coq/pull/10947

Without this, after `make`, the following files are untracked and not
ignored:

	.Makefile.coq.d
	Makefile.coq
	Makefile.coq.conf