### PR TITLE
Update .gitignore after recent PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 *.d
 *.vo
 *.vos
+*.vok
 *.glob
 *.aux
+.coq-native/
+.csdp.cache
+.lia.cache
+.nia.cache
+.nlia.cache
+.nra.cache
 /Makefile.conf
 /Makefile.coq.conf
+/Makefile.coq
 *~


### PR DESCRIPTION
Coq now generates .vok files and some of the hints use lia rather than omega.  I figured I might as well throw in the other caches while I was at it, in case Coq changes its defaults in the future.