### PR TITLE
Give Coq and its dependencies 20 minutes on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - eval $(opam config env)
 - opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev || echo "coq-core-dev registered"
 - opam repo add "${REPO_NAME}" "${REPO_URL}" || echo "${REPO_NAME} registered"
-- opam install coq.${COQ_VER} -y
+- travis_wait opam install coq.${COQ_VER} -y
 - opam install coq-bignums -y
 
 script:


### PR DESCRIPTION
If it needs more than 20 minutes, we can replace `travis_wait` with, e.g., `travis_wait 30`.

I've seen the install of Coq otherwise frequently time out after 10 minutes of no build output, c.f. https://travis-ci.com/JasonGross/coqprime/jobs/261043438?utm_medium=notification&utm_source=email