### PR TITLE
Adapt to Coq PR #12146: tactic subst now inactive on section variables with indirect dependency in goal

### DIFF
--- a/src/Coqprime/PrimalityTest/IGroup.v
+++ b/src/Coqprime/PrimalityTest/IGroup.v
@@ -169,9 +169,8 @@ Qed.
 Theorem inv_aux_inv: forall l a b, op a b = e -> op b a = e ->  (In a l) -> is_inv_aux l b = true.
 intros l a b; elim l; simpl.
 intros  _ _ H; case H.
-intros c l1 Rec H H0 H1; case H1; clear H1; intros H1; subst;  rewrite H.
-case (A_dec (op b a) e); case (A_dec e e); auto.
-intros H1 H2; contradict H2; rewrite H0; auto.
+intros c l1 Rec H H0 H1; case H1; clear H1; intros H1. subst c.
+case (A_dec (op b a) e); case (A_dec (op a b) e); auto.
 case (A_dec (op b c) e); case (A_dec (op c b) e); auto.
 Qed.
 

--- a/src/Coqprime/PrimalityTest/LucasLehmer.v
+++ b/src/Coqprime/PrimalityTest/LucasLehmer.v
@@ -260,9 +260,6 @@ apply trans_equal with (2 * q mod q).
 eq_tac; auto with zarith.
 apply Zdivide_mod; auto with zarith; exists 2; auto with zarith.
 apply is_inv_true with (2, q - 1); auto.
-apply mL_in; auto with zarith.
-intros; apply zpmult_1_l; auto with zarith.
-intros; apply zpmult_1_r; auto with zarith.
 rewrite zpmult_comm; auto.
 apply mL_in; auto with zarith.
 unfold w; apply mL_in; auto with zarith.
@@ -475,8 +472,6 @@ apply isupport_is_in; auto.
 apply is_inv_true with (1, 0); simpl; auto.
 intros; apply zpmult_1_l; auto with zarith.
 intros; apply zpmult_1_r; auto with zarith.
-rewrite zpmult_1_r; auto with zarith.
-rewrite zpmult_1_r; auto with zarith.
 exact w_in_pgroup.
 case H1.
 Qed.

--- a/src/Coqprime/PrimalityTest/Zp.v
+++ b/src/Coqprime/PrimalityTest/Zp.v
@@ -169,9 +169,6 @@ rewrite Z_mod_plus; auto with zarith.
 rewrite Zmod_small; auto with zarith.
 rewrite <- Hcd; ring.
 apply is_inv_true with (a := (c mod n)); auto.
-apply mkZp_in; auto with zarith.
-exact pmult_1_l.
-exact pmult_1_r.
 rewrite pmult_comm; auto.
 apply mkZp_in; auto with zarith.
 apply Z_mod_lt; auto with zarith.

--- a/src/Coqprime/elliptic/GZnZ.v
+++ b/src/Coqprime/elliptic/GZnZ.v
@@ -78,7 +78,7 @@ intros p; case p; intros x H.
    case (Zle_lt_or_eq 1 n); auto with zarith; intros Hz.
      rewrite (Zmod_small 1); auto with zarith.
      rewrite Zmult_1_l; auto.
-     subst n; rewrite znz1; rewrite H; rewrite znz1; auto.
+     clear p; subst n; rewrite znz1; rewrite H; rewrite znz1; auto.
 intros [x Hx] [y Hy].
   refine (zirr _ _ _ _ _); simpl.
   rewrite Zmult_comm; auto.


### PR DESCRIPTION
This is a backward-compatible change which can be merged now.

See [coq/coq#12139](https://github.com/coq/coq/issues/12139#issuecomment-622743684) for the motivation.

Note that this simplifies IGroup.is_inv_true which had 3 unnoticed useless arguments due to hidden dependencies in section variables.