### PR TITLE
Future proof ZCAux.v for 

### DIFF
--- a/src/Coqprime/Z/ZCAux.v
+++ b/src/Coqprime/Z/ZCAux.v
@@ -166,7 +166,7 @@ match a with
 | Z0 => 0
 | Zpos a' =>
     match b with
-    | Z0 => 0
+    | Z0 => ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact a end)
     | Zpos _ => Zmod_POS a' b
     | Zneg b' =>
         let r := Zmod_POS a' (Zpos b') in
@@ -174,7 +174,7 @@ match a with
     end
 | Zneg a' =>
     match b with
-    | Z0 => 0
+    | Z0 => ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact a end)
     | Zpos _ =>
         let r := Zmod_POS a' b in
         match r with Z0 =>  0 | _  =>  b - r end


### PR DESCRIPTION
This PR makes ZCAux.v work with https://github.com/coq/coq/pull/14086 in a backwards compatible manner.