### PR TITLE
Update README.md CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/thery/coqprime.svg?branch=master)](https://travis-ci.com/thery/coqprime)
+[![Build Status](https://github.com/thery/coqprime/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/thery/coqprime/actions/workflows/build.yml)
 
 # coqprime
 


### PR DESCRIPTION
It now points to the new GitHub Actions CI rather than the old Travis CI