### PR TITLE
Also test compat with Coq 8.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version: ['8.12', '8.13', '8.14', 'dev']
+        coq_version: ['8.11', '8.12', '8.13', '8.14', 'dev']
         ocaml_version: ['4.11-flambda']
       fail-fast: false  # don't stop jobs if one fails
     steps:

--- a/opam/opam
+++ b/opam/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12~"}
+  "coq" {>= "8.11~"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
Fiat Cryptography, which depends on coqprime, supports back to Coq 8.11,
so I'd like to have coqprime support back to 8.11 as well.