### PR TITLE
Compatibility with Coq 8.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version: ['8.12', '8.13', '8.14', 'dev']
+        coq_version: ['8.11', '8.12', '8.13', '8.14', 'dev']
         ocaml_version: ['4.11-flambda']
       fail-fast: false  # don't stop jobs if one fails
     steps:

--- a/opam/opam
+++ b/opam/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12~"}
+  "coq" {>= "8.11~"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"

--- a/src/Coqprime/num/W.v
+++ b/src/Coqprime/num/W.v
@@ -47,7 +47,7 @@ intros w op n H.
 rewrite mk_op_digits.
 rewrite <- (Zmult_1_r 1).
 apply Z.le_lt_trans with (2 ^ (Z_of_nat n) * 1)%Z.
-apply Zmult_le_compat_r;[| auto with zarith].
+apply Zmult_le_compat_r;[ | auto with zarith].
 rewrite <- (Zpower_0_r 2).
 apply Zpower_le_monotone; auto with zarith.
 apply Zmult_lt_compat_l; auto with zarith.


### PR DESCRIPTION
Fiat Cryptography, which depends on coqprime, supports back to Coq 8.11,
so I'd like to have coqprime support back to 8.11 as well.