### PR TITLE
Version-specific compatibility for adaptation to coq/coq#15754

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /Makefile.conf
 /Makefile.coq.conf
 /Makefile.coq
+/.coq-version
 *~
 gencertif/autom4te.cache
 gencertif/aclocal.m4
@@ -21,3 +22,4 @@ gencertif/config.log
 gencertif/config.status
 gencertif/configure
 gencertif/Makefile
+src/Coqprime/num/Int63Compat.v

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,5 @@ tests: all
 	@$(MAKE) -C tests -s all
 
 -include Makefile.coq
+
+include Makefile.coq.local-late

--- a/Makefile.coq.local-late
+++ b/Makefile.coq.local-late
@@ -1,0 +1,77 @@
+# We only want to inlcude this file once; in older versions of Coq it
+# gets included only in Makefile, while in newer versions it is also
+# included in Makefile.coq at the bottom
+ifndef MAKEFILE_COQ_LOCAL_LATE
+MAKEFILE_COQ_LOCAL_LATE:=yes
+
+# The list of files that depend on the version of Coq
+COMPATIBILITY_FILES := \
+	src/Coqprime/num/Int63Compat.v \
+	#
+
+# The file holding the version of Coq this project was last built with, locally
+COQ_VERSION_FILE := .coq-version
+# The version of Coq this project was last built with, locally
+COQ_EXTENDED_VERSION_OLD := $(shell cat $(COQ_VERSION_FILE) 2>/dev/null)
+# Parse the version of Coq
+# If we only care about supporting newer versions of Coq, we might
+# want to copy Makefile.coq and use
+# $(shell $(COQC) --print-version | cut -d " " -f 1)
+# instead of this $(firstword $(subst ...)) construct
+COQ_VERSION_PREFIX := The Coq Proof Assistant, version
+COQ_VERSION := $(firstword $(subst $(COQ_VERSION_PREFIX),,$(shell $(COQBIN)coqc --version 2>/dev/null)))
+COQ_EXTENDED_VERSION := $(shell (true | $(COQBIN)coqtop 2>/dev/null; $(COQBIN)coqc --version 2>/dev/null))
+
+# Set up EXPECTED_EXT based on supported versions
+ifneq (,$(filter 8.11%,$(COQ_VERSION)))
+EXPECTED_EXT:=.v811
+else
+ifneq (,$(filter 8.12%,$(COQ_VERSION)))
+EXPECTED_EXT:=.v812
+else
+ifneq (,$(filter 8.13%,$(COQ_VERSION)))
+EXPECTED_EXT:=.v813
+else
+ifneq (,$(filter 8.14%,$(COQ_VERSION)))
+EXPECTED_EXT:=.v814
+else
+ifneq (,$(filter 8.15%,$(COQ_VERSION)))
+EXPECTED_EXT:=.v815
+else
+EXPECTED_EXT:=.v816
+endif
+endif
+endif
+endif
+endif
+
+# For ease of changing versions of Coq, invalidate the various build
+# outputs when the version of Coq changes
+.merlin: $(COQ_VERSION_FILE)
+
+$(VOFILES) $(CMOFILES) $(CMXFILES) $(OFILES) $(CMAFILES) $(CMIFILES) $(CMXSFILES): $(COQ_VERSION_FILE)
+
+# Copy the compatibility files when either the version changes or the
+# underlying contents changes
+$(COMPATIBILITY_FILES) : % : %$(EXPECTED_EXT) $(COQ_VERSION_FILE)
+	$(SHOW)'CP $@{$(EXPECTED_EXT),}'
+	$(HIDE)cp $< $@
+
+# ensure that the compat files exist before we call coqdep
+$(ALLDFILES): $(COMPATIBILITY_FILES) $(COQ_VERSION_FILE) _CoqProject
+
+# The version file is generated and should be removed by clean
+clean::
+	rm -f $(COQ_VERSION_FILE)
+
+# If the version of Coq does not match the version the project was
+# last built with locally (or the version file does not exist), then
+# we record the version info
+ifneq ($(COQ_EXTENDED_VERSION),$(COQ_EXTENDED_VERSION_OLD))
+$(COQ_VERSION_FILE):
+	$(SHOW)'echo $$COQ_VERSION_INFO ($(COQ_VERSION)) > $@'
+	$(HIDE)echo "$(COQ_EXTENDED_VERSION)" > $@
+.PHONY: $(COQ_VERSION_FILE)
+endif
+
+endif

--- a/_CoqProject
+++ b/_CoqProject
@@ -7,7 +7,7 @@ src/Coqprime/List/ListAux.v
 src/Coqprime/List/Permutation.v
 src/Coqprime/List/UList.v
 src/Coqprime/List/ZProgression.v
-src/Coqprime/Z/Pmod.v 
+src/Coqprime/Z/Pmod.v
 src/Coqprime/Z/ZCAux.v
 src/Coqprime/Z/Zmod.v
 src/Coqprime/Z/Ppow.v
@@ -31,6 +31,7 @@ src/Coqprime/elliptic/GZnZ.v
 src/Coqprime/elliptic/SMain.v
 src/Coqprime/elliptic/ZEll.v
 src/Coqprime/num/Bits.v
+src/Coqprime/num/Int63Compat.v
 src/Coqprime/num/Lucas.v
 src/Coqprime/num/NEll.v
 src/Coqprime/num/MEll.v
@@ -40,6 +41,3 @@ src/Coqprime/num/montgomery.v
 src/Coqprime/num/W.v
 src/Coqprime/examples/BasePrimes.v
 src/Coqprime/examples/PocklingtonRefl.v
-
-
-

--- a/src/Coqprime/num/Int63Compat.v.v811
+++ b/src/Coqprime/num/Int63Compat.v.v811
@@ -1,0 +1,1 @@
+From Coq Require Export Int63.

--- a/src/Coqprime/num/Int63Compat.v.v812
+++ b/src/Coqprime/num/Int63Compat.v.v812
@@ -1,0 +1,1 @@
+From Coq Require Export Int63.

--- a/src/Coqprime/num/Int63Compat.v.v813
+++ b/src/Coqprime/num/Int63Compat.v.v813
@@ -1,0 +1,1 @@
+From Coq Require Export Int63.

--- a/src/Coqprime/num/Int63Compat.v.v814
+++ b/src/Coqprime/num/Int63Compat.v.v814
@@ -1,0 +1,1 @@
+From Coq Require Export Int63.

--- a/src/Coqprime/num/Int63Compat.v.v815
+++ b/src/Coqprime/num/Int63Compat.v.v815
@@ -1,0 +1,1 @@
+From Coq Require Export Int63.

--- a/src/Coqprime/num/Int63Compat.v.v816
+++ b/src/Coqprime/num/Int63Compat.v.v816
@@ -1,0 +1,1 @@
+From Coq Require Export Uint63.

--- a/src/Coqprime/num/Lucas.v
+++ b/src/Coqprime/num/Lucas.v
@@ -9,7 +9,7 @@
 Set Implicit Arguments.
 
 Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63.
+Require Import CyclicAxioms Cyclic63 Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
 Require Import ZCAux.
 Require Import W.

--- a/src/Coqprime/num/NEll.v
+++ b/src/Coqprime/num/NEll.v
@@ -8,7 +8,7 @@
 
 
 Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63.
+Require Import CyclicAxioms Cyclic63 Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
 Require Import W.
 Require Import Mod_op.

--- a/src/Coqprime/num/Pock.v
+++ b/src/Coqprime/num/Pock.v
@@ -13,7 +13,7 @@ Require Import ZCAux.
 Require Import LucasLehmer.
 Require Import Pocklington.
 Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63.
+Require Import CyclicAxioms Cyclic63 Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
 Require Import Pmod.
 Require Import Mod_op.

--- a/src/Coqprime/num/W.v
+++ b/src/Coqprime/num/W.v
@@ -7,7 +7,7 @@
 (*************************************************************)
 
 Set Implicit Arguments.
-Require Import CyclicAxioms Cyclic63 Int63.
+Require Import CyclicAxioms Cyclic63 Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
 Require Import ZArith ZCAux Mod_op.
 


### PR DESCRIPTION
Supercedes and closes #44
Adaptation for coq/coq#15754

I've copied over some version compat infrastructure from coq-rewriter, while improving it and documenting it a bit more.  The basic idea is that we parse the version of Coq, record it in .coq-version (only when the version has changed from the last build, though!), tell Coq that all build outputs depend on .coq-version (this is why it's important that .coq-version is only changed when there's actually a change in the version of Coq), and then say that Int63Compat.v is generated by copying over the relevant version-specific file.

This infrastructure will only have to be updated when we need to make version-specific changes to coqprime in the future (that is, it is future-proof against new 8.* versions of Coq, at least up to version 8.109; we'll need to adapt it if Coq gets up to version 8.110).