### PR TITLE
Use default ocaml version for compat with new docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    labels:
+      - "dependencies"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         coq_version: ['8.11', '8.12', '8.13', '8.14', '8.15', 'dev']
-        ocaml_version: ['4.11-flambda']
+        ocaml_version: ['default']
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Also enable dependabot updates, in case the docker action gets updated