### PR TITLE
Fix removal of `#[global]` in legacy-build script

### DIFF
--- a/.github/workflows/build-legacy.yml
+++ b/.github/workflows/build-legacy.yml
@@ -20,7 +20,7 @@ jobs:
           custom_script: |
             opam install -y coq-bignums
             sudo chmod -R a+rw .
-            git ls-files "*.v" | xargs sed -i 's/#[global]//g'
+            git ls-files "*.v" | xargs sed -i 's/#\[global\]//g'
             make src/Coqprime/PrimalityTest/Zp.vo
           coq_version: ${{ matrix.coq_version }}
           ocaml_version: ${{ matrix.ocaml_version }}


### PR DESCRIPTION
It wasn't previously doing anything.  I guess that means an alternative is removing this `sed` line altogether, as I guess the files that were modified aren't actually needed for fiat-crypto-legacy.  @thery if you'd prefer that I just remove this line, let me know, and I'll do that instead.