### PR TITLE
use modern opam in-repo setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version: ['8.11', '8.12', '8.13', '8.14', '8.15', 'dev']
+        coq_version: ['8.12', '8.13', '8.14', '8.15', 'dev']
         ocaml_version: ['default']
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
-          opam_file: 'coqprime.opam'
+          opam_file: 'coq-coqprime.opam'
           coq_version: ${{ matrix.coq_version }}
           ocaml_version: ${{ matrix.ocaml_version }}

--- a/coq-coqprime.opam
+++ b/coq-coqprime.opam
@@ -13,10 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.11~"}
+  "coq" {>= "8.12~"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"
-url {
-  src: "git+https://github.com/thery/coqprime.git#master"
-}

--- a/coqprime.opam
+++ b/coqprime.opam
@@ -1,1 +1,0 @@
-opam/opam

--- a/opam/descr
+++ b/opam/descr
@@ -1,1 +1,0 @@
-Certifying prime numbers in Coq

--- a/opam/url
+++ b/opam/url
@@ -1,3 +1,0 @@
-http: "https://github.com/thery/coqprime/archive/v8.8.zip"
-checksum: "3430856778d10abe378fbdd385ac834d"
-


### PR DESCRIPTION
The `descr`/`url` files for opam are obsolete. Here I change to the conventional setup for in-repo opam files. The package name is now the same as in the Coq opam archive. Based on #63, 8.11 is not supported, so I remove that from CI.