### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/src/Coqprime/PrimalityTest/Pocklington.v
+++ b/src/Coqprime/PrimalityTest/Pocklington.v
@@ -136,7 +136,7 @@ pose (c := (X /  F1)).
 assert(Hc1: 0 <= c).
 apply Z.ge_le; unfold c; apply Z_div_ge0; auto with zarith.
 assert (Hc2: X = c * F1 + 1).
-rewrite (Z_div_mod_eq X F1) by auto with zarith.
+rewrite (Z_div_mod_eq_full X F1).
 eq_tac.
 rewrite (Zmult_comm F1); auto.
 apply PocklingtonCorollary2 with (R1 := R1) (4 := H4); auto with zarith.
@@ -154,7 +154,7 @@ apply Z.ge_le; unfold d; repeat apply Z_div_ge0; auto with zarith.
 assert(Hd1: 0 <= d).
 apply Z.ge_le; unfold d; repeat apply Z_div_ge0; auto with zarith.
 assert (Hd2: N / X =  d * F1 + 1).
-rewrite (Z_div_mod_eq (N / X) F1) by auto with zarith.
+rewrite (Z_div_mod_eq_full (N / X) F1).
 eq_tac.
 rewrite (Zmult_comm F1); auto.
 apply PocklingtonCorollary2 with (R1 := R1) (4 := H4). 1-4: auto with zarith.
@@ -226,7 +226,7 @@ unfold r; apply Z_mod_lt; auto with zarith.
 assert (L11: 2 * s  = c * d).
 apply Zmult_reg_r with F1. auto with zarith.
 apply trans_equal with (R1 - (c + d)).
-rewrite L10; rewrite (Z_div_mod_eq R1 (2 * F1)). 2: auto with zarith.
+rewrite L10; rewrite (Z_div_mod_eq_full R1 (2 * F1)).
 unfold s, r; ring.
 rewrite L6; ring.
 case H8; intro H10.
@@ -255,7 +255,7 @@ case (Zle_lt_or_eq 0 r); unfold r.
 case (Z_mod_lt R1 (2 * F1)); auto with zarith.
 intros HH; repeat ((rewrite <- (Zplus_0_r 0); apply Zplus_le_compat)); auto with zarith.
 intros HH; contradict ER1; apply Zeven_not_Zodd.
-rewrite (Z_div_mod_eq R1 (2 * F1)) by auto with zarith.
+rewrite (Z_div_mod_eq_full R1 (2 * F1)).
 rewrite <- HH; rewrite Zplus_0_r.
 rewrite <- Zmult_assoc; apply Zeven_2p.
 Qed.

--- a/src/Coqprime/PrimalityTest/PocklingtonCertificat.v
+++ b/src/Coqprime/PrimalityTest/PocklingtonCertificat.v
@@ -434,7 +434,7 @@ Proof.
   assert ( 0 <= a mod b < b).
    apply Z_mod_lt; mauto.
   destruct (mod_unique b (a/b) (a mod b) 0 a H0 H); mauto.
-  rewrite <- Z_div_mod_eq; mauto.
+  rewrite <- Z_div_mod_eq_full; mauto.
 Qed.
 
 Lemma Npred_mod_spec : forall p n, Z_of_N p < Zpos n ->
@@ -681,7 +681,7 @@ Proof.
   apply mod_unique with (2 * mkProd dec).
  revert H8; mauto.
  apply Z_mod_lt; mauto.
- rewrite <- Z_div_mod_eq by mauto; rewrite H7.
+ rewrite <- Z_div_mod_eq_full; rewrite H7.
  simpl fst; simpl snd; simpl Z_of_N.
  ring. }
  destruct H15 as (H15,Heqr).

--- a/src/Coqprime/PrimalityTest/Zp.v
+++ b/src/Coqprime/PrimalityTest/Zp.v
@@ -176,7 +176,7 @@ apply is_inv_false.
 intros c H1; left; intros H2; contradict H.
 apply bezout_rel_prime.
 apply Bezout_intro with c  (- (Z.div (c * a) n)).
-pattern (c * a) at 1; rewrite (Z_div_mod_eq (c * a) n); auto with zarith.
+pattern (c * a) at 1; rewrite (Z_div_mod_eq_full (c * a) n).
 unfold pmult in H2; rewrite (Zmult_comm c); try rewrite H2.
 ring.
 Qed.

--- a/src/Coqprime/Z/Zmod.v
+++ b/src/Coqprime/Z/Zmod.v
@@ -88,7 +88,7 @@ Lemma Zmod_div_mod: forall n m a, 0 < n -> 0 < m ->
   (n | m) -> a mod n = (a mod m) mod n.
 Proof.
 intros n m a H1 H2 H3.
-pattern a at 1; rewrite (Z_div_mod_eq a m); auto with zarith.
+pattern a at 1; rewrite (Z_div_mod_eq_full a m).
 case H3; intros q Hq; pattern m at 1; rewrite Hq.
 rewrite (Zmult_comm q).
 rewrite Zplus_mod; auto.

--- a/src/Coqprime/elliptic/ZEll.v
+++ b/src/Coqprime/elliptic/ZEll.v
@@ -930,7 +930,7 @@ Local Coercion Zpos : positive >-> Z.
  field_simplify_eq; auto.
  unfold ninv, pkopp, GZnZ.opp, to_p, pK; apply zirr.
  simpl; rewrite <- Zmod_div_mod; auto with zarith.
- pattern y at 1; rewrite (Z_div_mod_eq y p); auto with zarith.
+ pattern y at 1; rewrite (Z_div_mod_eq_full y p).
  rewrite Zopp_plus_distr.
  rewrite Zopp_mult_distr_r.
  rewrite Zmult_comm; rewrite Zplus_comm;
@@ -1279,7 +1279,7 @@ Section pell.
     rewrite (Zmodml (27 * B)); auto.
     rewrite <- Zplus_mod; auto.
     rewrite Zmodml; auto; fold d; clear Hz1; intros Hz1.
-    rewrite (Z_div_mod_eq (z1 * d) N); auto with zarith.
+    rewrite (Z_div_mod_eq_full (z1 * d) N).
     rewrite (Zmult_comm z1).
     rewrite (Zmult_comm N).
     rewrite Zplus_assoc.

--- a/src/Coqprime/num/Bits.v
+++ b/src/Coqprime/num/Bits.v
@@ -51,7 +51,7 @@ assert (H1: Zpos q > 0); auto with zarith.
 assert (H1b: Zpos p >= 0).
   red; intros; discriminate.
 generalize (Z_div_ge0 (Zpos p) (Zpos q) H1 H1b).
-generalize (Z_div_mod_eq (Zpos p) (Zpos q) H1); case Z.div.
+generalize (Z_div_mod_eq_full (Zpos p) (Zpos q)); case Z.div.
   intros HH _; rewrite HH; rewrite Zmult_0_r; rewrite Zmult_1_r; simpl.
 case (Z_mod_lt (Zpos p) (Zpos q) H1); auto with zarith.
 intros q1 H2.

--- a/src/Coqprime/num/Mod_op.v
+++ b/src/Coqprime/num/Mod_op.v
@@ -967,7 +967,7 @@ Notation "[[ x ]]" :=
  Theorem mmul_aux2:forall x,
    x mod (2 ^ Zpos p - 1) =
     ((x / 2 ^ Zpos p) + (x mod 2 ^ Zpos p)) mod (2 ^ Zpos p - 1).
- intros x; pattern x at 1; rewrite Z_div_mod_eq with (b := 2 ^ Zpos p); auto with zarith.
+ intros x; pattern x at 1; rewrite Z_div_mod_eq_full with (b := 2 ^ Zpos p).
  match goal with |- (?X * ?Y + ?Z) mod (?X - 1) = ?T =>
   replace (X * Y + Z) with (Y * (X - 1) + (Y + Z)); try ring
  end.

--- a/src/Coqprime/num/NEll.v
+++ b/src/Coqprime/num/NEll.v
@@ -537,7 +537,7 @@ rewrite <- (Z_mod_plus) with (b := -(-z2Z y1 /exx.(vN))); auto with zarith.
 rewrite <- Zopp_mult_distr_l.
 rewrite <- Zopp_plus_distr.
 rewrite Zmult_comm; rewrite Zplus_comm.
-rewrite <- Z_div_mod_eq; auto with zarith.
+rewrite <- Z_div_mod_eq_full.
 rewrite Z.opp_involutive; rewrite <- z2ZN.
 apply sym_equal; auto.
 Qed.
@@ -580,7 +580,7 @@ intros p Hrec b x sc H1 H2.
     rewrite <- Zopp_mult_distr_l.
     rewrite <- Zopp_plus_distr.
     rewrite Zmult_comm; rewrite Zplus_comm.
-    rewrite <- Z_div_mod_eq; auto with zarith.
+    rewrite <- Z_div_mod_eq_full.
     rewrite Z.opp_involutive; rewrite <- z2ZN.
     apply sym_equal; auto.
     generalize H1; case x; auto.
@@ -610,7 +610,7 @@ intros p Hrec b x sc H1 H2.
     rewrite <- Zopp_mult_distr_l.
     rewrite <- Zopp_plus_distr.
     rewrite Zmult_comm; rewrite Zplus_comm.
-    rewrite <- Z_div_mod_eq; auto with zarith.
+    rewrite <- Z_div_mod_eq_full.
     rewrite Z.opp_involutive; rewrite <- z2ZN.
     apply sym_equal; auto.
     generalize H1; case x; auto.

--- a/src/Coqprime/num/Pock.v
+++ b/src/Coqprime/num/Pock.v
@@ -438,7 +438,7 @@ repeat rewrite Zpos_mult; auto with zarith.
 assert (HH:Z_of_N s = R1 / (2 * mkProd dec) /\ Zpos r =  R1 mod (2 * mkProd dec)).
 apply mod_unique with (2 * mkProd dec); [auto with zarith | | ].
 apply Z_mod_lt; auto with zarith.
-rewrite <- Z_div_mod_eq by auto with zarith.
+rewrite <- Z_div_mod_eq_full.
 rewrite H3.
 rewrite (Zpos_xO (mkProd dec)).
 simpl Z_of_N; ring.


### PR DESCRIPTION
Use `Zdiv.Z_div_mod_eq_full` instead of deprecated `Zdiv.Z_div_mod_eq` (coq/coq#16920).