### PR TITLE
Qualify Require statements with library name

### DIFF
--- a/src/Coqprime/List/Iterator.v
+++ b/src/Coqprime/List/Iterator.v
@@ -6,9 +6,9 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Export List.
-Require Export Permutation.
-Require Import Arith.
+From Coq Require Export List.
+From Coqprime Require Export Permutation.
+From Coq Require Import Arith.
 
 Section Iterator.
 Variables A B : Set.

--- a/src/Coqprime/List/ListAux.v
+++ b/src/Coqprime/List/ListAux.v
@@ -11,11 +11,11 @@
 
      Auxillary functions & Theorems
   **********************************************************************)
-Require Export List.
-Require Export Arith.
-Require Export Tactic.
-Require Import Inverse_Image.
-Require Import Wf_nat.
+From Coq Require Export List.
+From Coq Require Export Arith.
+From Coqprime Require Export Tactic.
+From Coq Require Import Inverse_Image.
+From Coq Require Import Wf_nat.
 
 (**************************************
    Some properties on list operators: app, map,...

--- a/src/Coqprime/List/Permutation.v
+++ b/src/Coqprime/List/Permutation.v
@@ -11,8 +11,8 @@
 
     Defintion and properties of permutations
    **********************************************************************)
-Require Export List.
-Require Export ListAux.
+From Coq Require Export List.
+From Coqprime Require Export ListAux.
 
 Section permutation.
 Variable A : Set.

--- a/src/Coqprime/List/UList.v
+++ b/src/Coqprime/List/UList.v
@@ -13,10 +13,10 @@
 
       Definition: ulist
 ************************************************************************)
-Require Import List.
-Require Import Arith.
-Require Import Permutation.
-Require Import ListSet.
+From Coq Require Import List.
+From Coq Require Import Arith.
+From Coqprime Require Import Permutation.
+From Coq Require Import ListSet.
 
 Section UniqueList.
 Variable A : Set.

--- a/src/Coqprime/List/ZProgression.v
+++ b/src/Coqprime/List/ZProgression.v
@@ -6,10 +6,10 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Export Iterator.
-Require Import ZArith.
-Require Import Lia.
-Require Export UList.
+From Coqprime Require Export Iterator.
+From Coq Require Import ZArith.
+From Coq Require Import Lia.
+From Coqprime Require Export UList.
 Open Scope Z_scope.
 
 Theorem next_n_Z: forall n m,  next_n Z.succ n m = n + Z_of_nat m.

--- a/src/Coqprime/N/ChineseRem.v
+++ b/src/Coqprime/N/ChineseRem.v
@@ -1,9 +1,9 @@
-Require Import Arith.
-Require Import Wf_nat.
-Require Import ZArith.
-Require Import Peano_dec.
-Require Import ZArith_dec.
-Require Import NatAux ZCAux ZCmisc ZSum Pmod Ppow.
+From Coq Require Import Arith.
+From Coq Require Import Wf_nat.
+From Coq Require Import ZArith.
+From Coq Require Import Peano_dec.
+From Coq Require Import ZArith_dec.
+From Coqprime Require Import NatAux ZCAux ZCmisc ZSum Pmod Ppow.
 
 Open Scope nat_scope.
 

--- a/src/Coqprime/N/NatAux.v
+++ b/src/Coqprime/N/NatAux.v
@@ -11,7 +11,7 @@
 
      Auxillary functions & Theorems
  **********************************************************************)
-Require Export Arith.
+From Coq Require Export Arith.
 
 (**************************************
   Some properties of minus

--- a/src/Coqprime/PrimalityTest/Cyclic.v
+++ b/src/Coqprime/PrimalityTest/Cyclic.v
@@ -11,13 +11,13 @@
 
       Proof that an abelien ring is cyclic
  ************************************************************************)
-Require Import ZCAux.
-Require Import List.
-Require Import Root.
-Require Import UList.
-Require Import IGroup.
-Require Import EGroup.
-Require Import FGroup.
+From Coqprime Require Import ZCAux.
+From Coq Require Import List.
+From Coqprime Require Import Root.
+From Coqprime Require Import UList.
+From Coqprime Require Import IGroup.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import FGroup.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/EGroup.v
+++ b/src/Coqprime/PrimalityTest/EGroup.v
@@ -11,15 +11,15 @@
 
     Given an element a, create the group {e, a, a^2, ..., a^n}
  **********************************************************************)
-Require Import ZArith.
-Require Import Tactic.
-Require Import List.
-Require Import ZCAux.
-Require Import ZArith Znumtheory.
-Require Import Wf_nat.
-Require Import UList.
-Require Import FGroup.
-Require Import Lagrange.
+From Coq Require Import ZArith.
+From Coqprime Require Import Tactic.
+From Coq Require Import List.
+From Coqprime Require Import ZCAux.
+From Coq Require Import ZArith Znumtheory.
+From Coq Require Import Wf_nat.
+From Coqprime Require Import UList.
+From Coqprime Require Import FGroup.
+From Coqprime Require Import Lagrange.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Euler.v
+++ b/src/Coqprime/PrimalityTest/Euler.v
@@ -11,10 +11,10 @@
     Definition of the Euler Totient function
 
 *************************************************************************)
-Require Import ZArith.
-Require Export Znumtheory.
-Require Import Tactic.
-Require Export ZSum.
+From Coq Require Import ZArith.
+From Coq Require Export Znumtheory.
+From Coqprime Require Import Tactic.
+From Coqprime Require Export ZSum.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/FGroup.v
+++ b/src/Coqprime/PrimalityTest/FGroup.v
@@ -13,10 +13,10 @@
 
     Definition: FGroup
   **********************************************************************)
-Require Import List.
-Require Import UList.
-Require Import Tactic.
-Require Import ZArith.
+From Coq Require Import List.
+From Coqprime Require Import UList.
+From Coqprime Require Import Tactic.
+From Coq Require Import ZArith.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/IGroup.v
+++ b/src/Coqprime/PrimalityTest/IGroup.v
@@ -13,12 +13,12 @@
 
     Definition: ZpGroup
   **********************************************************************)
-Require Import ZArith.
-Require Import Tactic.
-Require Import Wf_nat.
-Require Import UList.
-Require Import ListAux.
-Require Import FGroup.
+From Coq Require Import ZArith.
+From Coqprime Require Import Tactic.
+From Coq Require Import Wf_nat.
+From Coqprime Require Import UList.
+From Coqprime Require Import ListAux.
+From Coqprime Require Import FGroup.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Lagrange.v
+++ b/src/Coqprime/PrimalityTest/Lagrange.v
@@ -14,12 +14,12 @@
 
     Definition: lagrange
   **********************************************************************)
-Require Import List.
-Require Import UList.
-Require Import ListAux.
-Require Import ZArith Znumtheory.
-Require Import NatAux.
-Require Import FGroup.
+From Coq Require Import List.
+From Coqprime Require Import UList.
+From Coqprime Require Import ListAux.
+From Coq Require Import ZArith Znumtheory.
+From Coqprime Require Import NatAux.
+From Coqprime Require Import FGroup.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/LucasLehmer.v
+++ b/src/Coqprime/PrimalityTest/LucasLehmer.v
@@ -13,17 +13,17 @@
 
     Definition: LucasLehmer
   **********************************************************************)
-Require Import ZArith.
-Require Import ZCAux.
-Require Import Tactic.
-Require Import Wf_nat.
-Require Import NatAux.
-Require Import UList.
-Require Import ListAux.
-Require Import FGroup.
-Require Import EGroup.
-Require Import PGroup.
-Require Import IGroup.
+From Coq Require Import ZArith.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import Tactic.
+From Coq Require Import Wf_nat.
+From Coqprime Require Import NatAux.
+From Coqprime Require Import UList.
+From Coqprime Require Import ListAux.
+From Coqprime Require Import FGroup.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import PGroup.
+From Coqprime Require Import IGroup.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/PGroup.v
+++ b/src/Coqprime/PrimalityTest/PGroup.v
@@ -14,15 +14,15 @@
 
     Definition: PGroup
  **********************************************************************)
-Require Import ZArith.
-Require Import Znumtheory.
-Require Import Tactic.
-Require Import Wf_nat.
-Require Import ListAux.
-Require Import UList.
-Require Import FGroup.
-Require Import EGroup.
-Require Import IGroup.
+From Coq Require Import ZArith.
+From Coq Require Import Znumtheory.
+From Coqprime Require Import Tactic.
+From Coq Require Import Wf_nat.
+From Coqprime Require Import ListAux.
+From Coqprime Require Import UList.
+From Coqprime Require Import FGroup.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import IGroup.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Pepin.v
+++ b/src/Coqprime/PrimalityTest/Pepin.v
@@ -13,9 +13,9 @@
 
     Definition: PepinTest
   **********************************************************************)
-Require Import ZArith.
-Require Import ZCAux.
-Require Import Pocklington.
+From Coq Require Import ZArith.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import Pocklington.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Pocklington.v
+++ b/src/Coqprime/PrimalityTest/Pocklington.v
@@ -6,14 +6,14 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import ZArith.
-Require Export Znumtheory.
-Require Import Tactic.
-Require Import ZCAux.
-Require Import Zp.
-Require Import FGroup.
-Require Import EGroup.
-Require Import Euler.
+From Coq Require Import ZArith.
+From Coq Require Export Znumtheory.
+From Coqprime Require Import Tactic.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import Zp.
+From Coqprime Require Import FGroup.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import Euler.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/PocklingtonCertificat.v
+++ b/src/Coqprime/PrimalityTest/PocklingtonCertificat.v
@@ -6,14 +6,14 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import List.
-Require Import ZArith.
-Require Import Zorder.
-Require Import ZCAux.
-Require Import LucasLehmer.
-Require Import Pocklington.
-Require Import ZCmisc.
-Require Import Pmod.
+From Coq Require Import List.
+From Coq Require Import ZArith.
+From Coq Require Import Zorder.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import LucasLehmer.
+From Coqprime Require Import Pocklington.
+From Coqprime Require Import ZCmisc.
+From Coqprime Require Import Pmod.
 
 (* Compatibility with Coq versions not supporting hint localities *)
 Set Warnings "-unsupported-attributes".

--- a/src/Coqprime/PrimalityTest/Proth.v
+++ b/src/Coqprime/PrimalityTest/Proth.v
@@ -13,9 +13,9 @@
 
     Definition: ProthTest
  **********************************************************************)
-Require Import ZArith.
-Require Import ZCAux.
-Require Import Pocklington.
+From Coq Require Import ZArith.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import Pocklington.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Root.v
+++ b/src/Coqprime/PrimalityTest/Root.v
@@ -11,11 +11,11 @@
 
       Proof that a polynomial has at most n roots
 ************************************************************************)
-Require Import ZArith.
-Require Import List.
-Require Import UList.
-Require Import Tactic.
-Require Import Permutation.
+From Coq Require Import ZArith.
+From Coq Require Import List.
+From Coqprime Require Import UList.
+From Coqprime Require Import Tactic.
+From Coqprime Require Import Permutation.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/PrimalityTest/Zp.v
+++ b/src/Coqprime/PrimalityTest/Zp.v
@@ -14,16 +14,16 @@
 
     Definition: ZpGroup
  **********************************************************************)
-Require Import ZArith Znumtheory Zpow_facts.
-Require Import Tactic.
-Require Import Wf_nat.
-Require Import UList.
-Require Import FGroup.
-Require Import EGroup.
-Require Import IGroup.
-Require Import Cyclic.
-Require Import Euler.
-Require Import ZProgression.
+From Coq Require Import ZArith Znumtheory Zpow_facts.
+From Coqprime Require Import Tactic.
+From Coq Require Import Wf_nat.
+From Coqprime Require Import UList.
+From Coqprime Require Import FGroup.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import IGroup.
+From Coqprime Require Import Cyclic.
+From Coqprime Require Import Euler.
+From Coqprime Require Import ZProgression.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/Z/Pmod.v
+++ b/src/Coqprime/Z/Pmod.v
@@ -6,8 +6,8 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Export ZArith Lia.
-Require Export ZCmisc.
+From Coq Require Export ZArith Lia Zwf.
+From Coqprime Require Export ZCmisc.
 
 (* Compatibility with Coq versions not supporting hint localities *)
 Set Warnings "-unsupported-attributes".
@@ -382,9 +382,6 @@ Qed.
 Lemma gcd_log2_mod0 :
   forall a b c, a mod b = N0 -> gcd_log2 a b c = Some b.
 Proof. intros a b c H;destruct c;simpl;rewrite H;trivial. Qed.
-
-
-Require Import Zwf.
 
 Lemma Zwf_pos : well_founded (fun x y => Zpos x < Zpos y).
 Proof.

--- a/src/Coqprime/Z/Ppow.v
+++ b/src/Coqprime/Z/Ppow.v
@@ -5,7 +5,7 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import ZArith Zpow_facts.
+From Coq Require Import ZArith Zpow_facts.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/Z/ZCAux.v
+++ b/src/Coqprime/Z/ZCAux.v
@@ -12,10 +12,10 @@
      Auxillary functions & Theorems
  **********************************************************************)
 
-Require Import ArithRing.
-Require Export ZArith Zpow_facts.
-Require Export Znumtheory.
-Require Export Tactic.
+From Coq Require Import ArithRing.
+From Coq Require Export ZArith Zpow_facts.
+From Coq Require Export Znumtheory.
+From Coqprime Require Export Tactic.
 
 Theorem Zdivide_div_prime_le_square:  forall x, 1 < x -> ~prime x -> exists p, prime p /\ (p | x) /\ p * p <= x.
 intros x Hx; generalize Hx; pattern x; apply Z_lt_induction. 2: auto with zarith.

--- a/src/Coqprime/Z/ZCmisc.v
+++ b/src/Coqprime/Z/ZCmisc.v
@@ -6,8 +6,7 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Export ZArith.
-Require Import Lia.
+From Coq Require Export ZArith Lia.
 
 (* Compatibility with Coq versions not supporting hint localities *)
 Set Warnings "-unsupported-attributes".

--- a/src/Coqprime/Z/ZSum.v
+++ b/src/Coqprime/Z/ZSum.v
@@ -9,13 +9,13 @@
 (***********************************************************************
     Summation.v from Z to Z
  *********************************************************************)
-Require Import Arith.
-Require Import ArithRing.
-Require Import ListAux.
-Require Import ZArith.
-Require Import Lia.
-Require Import Iterator.
-Require Import ZProgression.
+From Coq Require Import Arith.
+From Coq Require Import ArithRing.
+From Coqprime Require Import ListAux.
+From Coq Require Import ZArith.
+From Coq Require Import Lia.
+From Coqprime Require Import Iterator.
+From Coqprime Require Import ZProgression.
 
 
 Open Scope Z_scope.

--- a/src/Coqprime/Z/Zmod.v
+++ b/src/Coqprime/Z/Zmod.v
@@ -5,7 +5,7 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import ZArith Znumtheory.
+From Coq Require Import ZArith Znumtheory.
 
 Set Implicit Arguments.
 

--- a/src/Coqprime/elliptic/GZnZ.v
+++ b/src/Coqprime/elliptic/GZnZ.v
@@ -5,11 +5,11 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import ZArith Znumtheory.
-Require Import Eqdep_dec.
-Require Import List.
-Require Import Lia.
-Require Import UList.
+From Coq Require Import ZArith Znumtheory.
+From Coq Require Import Eqdep_dec.
+From Coq Require Import List.
+From Coq Require Import Lia.
+From Coqprime Require Import UList.
 
 Section ZnZ.
 
@@ -223,8 +223,8 @@ Qed.
 End ZnZ.
 
 
-Require Import Field.
-Require Import Pmod.
+From Coq Require Import Field.
+From Coqprime Require Import Pmod.
 
 Section ZpZ.
 

--- a/src/Coqprime/elliptic/SMain.v
+++ b/src/Coqprime/elliptic/SMain.v
@@ -5,14 +5,14 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import Arith_base.
-Require Import Field_tac.
-Require Import Ring.
-Require Import Eqdep_dec.
-Require Import FGroup.
-Require Import List.
-Require Import UList.
-Require Import ZArith.
+From Coq Require Import Arith_base.
+From Coq Require Import Field_tac.
+From Coq Require Import Ring.
+From Coq Require Import Eqdep_dec.
+From Coqprime Require Import FGroup.
+From Coq Require Import List.
+From Coqprime Require Import UList.
+From Coq Require Import ZArith.
 
 Set Implicit Arguments.
 

--- a/src/Coqprime/elliptic/ZEll.v
+++ b/src/Coqprime/elliptic/ZEll.v
@@ -5,17 +5,17 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import Ring.
-Require Import Field_tac.
-Require Import Ring_tac.
-Require Import Eqdep_dec.
-Require Import ZArith.
-Require Import ZCAux.
-Require Import Ppow.
-Require Import GZnZ.
-Require Import EGroup.
-Require Import SMain.
-Require Import Zmod.
+From Coq Require Import Ring.
+From Coq Require Import Field_tac.
+From Coq Require Import Ring_tac.
+From Coq Require Import Eqdep_dec.
+From Coq Require Import ZArith.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import Ppow.
+From Coqprime Require Import GZnZ.
+From Coqprime Require Import EGroup.
+From Coqprime Require Import SMain.
+From Coqprime Require Import Zmod.
 
 Set Implicit Arguments.
 

--- a/src/Coqprime/examples/BasePrimes.v
+++ b/src/Coqprime/examples/BasePrimes.v
@@ -6,11 +6,11 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import List.
-Require Import ZArith.
+From Coq Require Import List.
+From Coq Require Import ZArith.
 From Coqprime Require Import ZCAux.
 
-Require Import Pock.
+From Coqprime Require Import Pock.
 
 Local Open Scope positive_scope.
 

--- a/src/Coqprime/examples/PocklingtonRefl.v
+++ b/src/Coqprime/examples/PocklingtonRefl.v
@@ -6,8 +6,8 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Export List.
-Require Export ZArith.
-Require Export Znumtheory.
-Require Export Pock.
-Require Export BasePrimes.
+From Coq Require Export List.
+From Coq Require Export ZArith.
+From Coq Require Export Znumtheory.
+From Coqprime Require Export Pock.
+From Coqprime Require Export BasePrimes.

--- a/src/Coqprime/num/Bits.v
+++ b/src/Coqprime/num/Bits.v
@@ -1,4 +1,4 @@
-Require Import ZArith Zpow_facts.
+From Coq Require Import ZArith Zpow_facts.
 
 Open Scope Z_scope.
 

--- a/src/Coqprime/num/Lucas.v
+++ b/src/Coqprime/num/Lucas.v
@@ -8,14 +8,15 @@
 
 Set Implicit Arguments.
 
-Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63Compat.
+From Coq Require Import ZArith Znumtheory Zpow_facts.
+From Coq Require Import CyclicAxioms Cyclic63.
+From Coqprime Require Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
-Require Import ZCAux.
-Require Import W.
-Require Import Mod_op.
-Require Import LucasLehmer.
-Require Import Bits.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import W.
+From Coqprime Require Import Mod_op.
+From Coqprime Require Import LucasLehmer.
+From Coqprime Require Import Bits.
 Import CyclicAxioms DoubleType DoubleBase.
 
 Open Scope Z_scope.

--- a/src/Coqprime/num/MEll.v
+++ b/src/Coqprime/num/MEll.v
@@ -7,8 +7,8 @@
 (*************************************************************)
 
 
-Require Import ZArith Znumtheory Zpow_facts.
-Require Import Uint63 ZEll montgomery.
+From Coq Require Import ZArith Znumtheory Zpow_facts Uint63.
+From Coqprime Require Import ZEll montgomery.
 
 Set Implicit Arguments.
 

--- a/src/Coqprime/num/Mod_op.v
+++ b/src/Coqprime/num/Mod_op.v
@@ -10,8 +10,8 @@ Set Implicit Arguments.
 
 From Bignums Require Import DoubleBase DoubleSub DoubleMul DoubleSqrt DoubleLift DoubleDivn1 DoubleDiv.
 From Bignums Require Import DoubleCyclic BigN.
-Require Import CyclicAxioms Cyclic63.
-Require Import ZArith ZCAux.
+From Coq Require Import CyclicAxioms Cyclic63 ZArith.
+From Coqprime Require Import ZCAux.
 Import CyclicAxioms DoubleType DoubleBase.
 
 (* For backward compatibility. The intended value is Set,

--- a/src/Coqprime/num/NEll.v
+++ b/src/Coqprime/num/NEll.v
@@ -7,15 +7,16 @@
 (*************************************************************)
 
 
-Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63Compat.
+From Coq Require Import ZArith Znumtheory Zpow_facts.
+From Coq Require Import CyclicAxioms Cyclic63.
+From Coqprime Require Import Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
-Require Import W.
-Require Import Mod_op.
-Require Import ZEll.
-Require Import Bits.
+From Coqprime Require Import W.
+From Coqprime Require Import Mod_op.
+From Coqprime Require Import ZEll.
+From Coqprime Require Import Bits.
 Import CyclicAxioms DoubleType DoubleBase.
-Require Import Zmod.
+From Coqprime Require Import Zmod.
 
 
 Set Implicit Arguments.

--- a/src/Coqprime/num/Pock.v
+++ b/src/Coqprime/num/Pock.v
@@ -6,21 +6,23 @@
 (*    Benjamin.Gregoire@inria.fr Laurent.Thery@inria.fr      *)
 (*************************************************************)
 
-Require Import List.
-Require Import ZArith.
-Require Import Zorder.
-Require Import ZCAux.
-Require Import LucasLehmer.
-Require Import Pocklington.
-Require Import ZArith Znumtheory Zpow_facts.
-Require Import CyclicAxioms Cyclic63 Int63Compat.
+From Coq Require Import List.
+From Coq Require Import ZArith.
+From Coq Require Import Zorder.
+From Coqprime Require Import ZCAux.
+From Coqprime Require Import LucasLehmer.
+From Coqprime Require Import Pocklington.
+From Coq Require Import ZArith Znumtheory Zpow_facts.
+From Coq Require Import CyclicAxioms Cyclic63.
+From Coqprime Require Import Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
-Require Import Pmod.
-Require Import Mod_op.
-Require Import W.
-Require Import Lucas.
-Require Export PocklingtonCertificat.
-Require Import NEll.
+From Coqprime Require Import Pmod.
+From Coqprime Require Import Mod_op.
+From Coqprime Require Import W.
+From Coqprime Require Import Lucas.
+From Coqprime Require Export PocklingtonCertificat.
+From Coqprime Require Import NEll.
+From Coqprime Require Import Bits.
 Import CyclicAxioms DoubleType DoubleBase List.
 
 Open Scope Z_scope.
@@ -267,8 +269,6 @@ end.
 Qed.
 
 End test.
-
-Require Import Bits.
 
 Definition test_pock N a dec sqrt :=
   if (2 ?< N) then

--- a/src/Coqprime/num/W.v
+++ b/src/Coqprime/num/W.v
@@ -7,9 +7,11 @@
 (*************************************************************)
 
 Set Implicit Arguments.
-Require Import CyclicAxioms Cyclic63 Int63Compat.
+From Coq Require Import CyclicAxioms Cyclic63.
+From Coqprime Require Import Int63Compat.
 From Bignums Require Import DoubleCyclic BigN.
-Require Import ZArith ZCAux Mod_op.
+From Coq Require Import ZArith.
+From Coqprime Require Import ZCAux Mod_op.
 
 (* ** Type of words ** *)
 

--- a/src/Coqprime/num/extraction/extract.v
+++ b/src/Coqprime/num/extraction/extract.v
@@ -9,4 +9,4 @@ Recursive Extraction Library GenWord.
 Recursive Extraction Library Mod_op.
 Recursive Extraction Library Lucas.
 
-coqtop  -I ../ -I ../../Tactic -I ../../N -I ../../Z -I ../../PrimalityTest -I ../../List  -I ../W/W8
+(* coqtop  -I ../ -I ../../Tactic -I ../../N -I ../../Z -I ../../PrimalityTest -I ../../List  -I ../W/W8 *)

--- a/src/Coqprime/num/montgomery.v
+++ b/src/Coqprime/num/montgomery.v
@@ -1,4 +1,4 @@
-Require Import List ZArith Znumtheory Uint63 Cyclic63.
+From Coq Require Import List ZArith Znumtheory Uint63 Cyclic63.
 
 (* We are going to implement modular arithmetic with
    montgomery reduction


### PR DESCRIPTION
This will allow coqprime to be compiled even when .vo files with conflicting names are in loadpath. Specifying the name of the library with `From` is a compromise between robustness to changes in the set of installed libraries and robustness to changes in the path of a particular file within a library.